### PR TITLE
a read only collection doesn't work when deserializing from json

### DIFF
--- a/SolidworksAddinFramework/SelectionData.cs
+++ b/SolidworksAddinFramework/SelectionData.cs
@@ -49,7 +49,7 @@ namespace SolidworksAddinFramework
         public override string ToString() => $"SelectionData ( {Mark} - {ObjectIdsHuman}";
 
         [DataMember]
-        public IReadOnlyList<byte[]> ObjectIds { get; }
+        public List<byte[]> ObjectIds { get; }
 
         public string ObjectIdsHuman => string.Join(":",ObjectIds.Select(id => BitConverter.ToString(id, 0, id.Length)));
         [DataMember]
@@ -59,7 +59,7 @@ namespace SolidworksAddinFramework
 
         public SelectionData(IEnumerable<byte[]> objectIds, int mark)
         {
-            ObjectIds = new ReadOnlyCollection<byte[]>(objectIds.ToList());
+            ObjectIds = new List<byte[]>(objectIds.ToList());
             Mark = mark;
         }
     }


### PR DESCRIPTION
This makes the sample macro alpha split work.... sort of.  The bodies persistent id was being serialized to json but then the deserialization didn't work with the read only list.  Changing it to a regular list fixed that problem.  But maybe the readonly list was intentional to fix something else?  I noticed some other problems that may be related.  When you go to edit the feature now there are 3 items on the selection list.  If you made a change to the alpha and then commit again now there are 5.  So something isn't right.  I also noticed that if when you first call the "Split Alpha" method with a body already selected then the body is selected in the selection list but changing the alpha values doesn't have any visual affect on the selected body.  You have to select the body AFTER calling "Split Alpha" or the graphical split doesn't show.  But, if you do it that way and then right click the selection list and select "Clear Selection" the list does clear but the graphic continues to show the body as split.
