### PR TITLE
Persistent reference management

### DIFF
--- a/SolidworksAddinFramework.Spec/ModelDocSpecs.cs
+++ b/SolidworksAddinFramework.Spec/ModelDocSpecs.cs
@@ -106,5 +106,29 @@ namespace SolidworksAddinFramework.Spec
                 closed.Should().Be(2);
             }
         }
+
+        [SolidworksFact]
+        public async Task GettingPersistentEntityReferenceShouldWork()
+        {
+            await CreatePartDoc(false, async doc =>
+            {
+                var feature = SpecHelper.InsertDummyBody(doc);
+                var body = doc.GetBodiesTs().Single();
+                var box1 = body.GetBodyBoxTs();
+                // Attempts to invalidate `body`
+                // Attempt 1: change active configuration
+                var config = doc.ConfigurationManager.AddConfiguration("TestConfig", "", "", 0, "Default", "");
+                doc.ConfigurationManager.ActiveConfiguration.Should().Be(config);
+                // Attempt 2: Rebuild doc
+                doc.ForceRebuild3(false);
+                // Attempt 3: Insert delay
+                await Task.Delay(TimeSpan.FromSeconds(10));
+
+                // This still succeeds
+                var box2 = body.GetBodyBoxTs();
+
+                return Disposable.Empty;
+            });
+        }
     }
 }

--- a/SolidworksAddinFramework.Spec/ModelDocSpecs.cs
+++ b/SolidworksAddinFramework.Spec/ModelDocSpecs.cs
@@ -16,6 +16,8 @@ using SolidWorks.Interop.swconst;
 using XUnit;
 using XUnit.Solidworks.Addin;
 using SolidworksAddinFramework.Events;
+using System.Diagnostics;
+using SolidworksAddinFramework;
 
 namespace SolidworksAddinFramework.Spec
 {
@@ -115,6 +117,9 @@ namespace SolidworksAddinFramework.Spec
             {
                 var feature = SpecHelper.InsertDummyBody(doc);
                 var body = doc.GetBodiesTs().Single();
+                //TODO: If I comment out the code below it won't compile.  Why?
+                //var bodyPerst = doc.GetBodiesTs().Select(b => doc.GetPersistentEntityReference<IBody2>(b)).Single();
+                body.Name.Should().Be("Boss-Extrude1");
                 var box1 = body.GetBodyBoxTs();
 
                 // switch to new config
@@ -126,15 +131,16 @@ namespace SolidworksAddinFramework.Spec
                 doc.AddSelections(0, new[] { body });
                 var deleteFeature = doc.FeatureManager.InsertDeleteBody2(false);
                 doc.GetBodiesTs().Should().BeEmpty();
-                doc.ForceRebuild3(false);
-                new Action(() => body.GetBodyBoxTs()).ShouldThrow<COMException>().Which.Message.Should().Contain("disconnected");
+                body.Name.Should().Be("Boss-Extrude1");
+                var box2 = body.GetBodyBoxTs();
 
                 // switch back to default config
                 doc.ShowConfiguration2(defaultConfig.Name).Should().BeTrue();
                 doc.ConfigurationManager.ActiveConfiguration.Should().Be(defaultConfig);
-
-                var box2 = body.GetBodyBoxTs();
-
+                string name;
+                new Action(() => name = body.Name).ShouldThrow<SEHException>().Which.Message.Should().Contain("External");
+                new Action(() => body.GetBodyBoxTs()).ShouldThrow<COMException>().Which.Message.Should().Contain("disconnected");
+                //bodyPerst.Name.Should().Be("Boss-Extrude1");
                 return Disposable.Empty;
             });
         }

--- a/SolidworksAddinFramework/ModelDocExtensions.cs
+++ b/SolidworksAddinFramework/ModelDocExtensions.cs
@@ -158,6 +158,22 @@ namespace SolidworksAddinFramework
             return Tuple(selectedObjects, marks, views);
         }
 
+        public static Func<T> GetPersistentEntityReference<T>(IModelDoc2 modelDoc, T obj)
+        {
+            var persistReference = modelDoc.Extension.GetPersistReference(obj);
+            return fun(() =>
+            {
+                int errorCode;
+                var result = (T)modelDoc.Extension.GetObjectByPersistReference3(persistReference, out errorCode);
+                var error = (swPersistReferencedObjectStates_e)errorCode;
+                if (error != swPersistReferencedObjectStates_e.swPersistReferencedObject_Ok)
+                {
+                    throw new SelectionException($"GetObjectByPersistReference3 returned {error}");
+                }
+                return result;
+            });
+        }
+
         /// <summary>
         /// Doesn't work when intersecting with wire bodies. 
         /// </summary>

--- a/SolidworksAddinFramework/ModelDocExtensions.cs
+++ b/SolidworksAddinFramework/ModelDocExtensions.cs
@@ -70,6 +70,16 @@ namespace SolidworksAddinFramework
                 .Select(e => sm.GetSelectedObjects(filter));
         }
 
+        public static void AddSelections(this IModelDoc2 doc, int mark, IEnumerable<object> objects)
+        {
+            var selectionMgr = (ISelectionMgr) doc.SelectionManager;
+            var selectData = selectionMgr.CreateSelectData();
+            selectData.Mark = mark;
+
+            var count = doc.Extension.MultiSelect2(ComWangling.ObjectArrayToDispatchWrapper(objects), true, selectData);
+            //var count = selectionMgr.AddSelectionListObjects(ComWangling.ObjectArrayToDispatchWrapper(o.Objects), selectData);
+        }
+
         /// <summary>
         /// Add 
         /// </summary>
@@ -94,15 +104,7 @@ namespace SolidworksAddinFramework
                         return new { Mark = p.Key, Objects = objects };
                     })
                     .Where(p => p.Objects.Length > 0)
-                    .ForEach(o =>
-                    {
-                        var selectData = selectionMgr.CreateSelectData();
-                        selectData.Mark = o.Mark;
-
-                        var count = doc.Extension.MultiSelect2(ComWangling.ObjectArrayToDispatchWrapper(o.Objects), true,
-                            selectData);
-                        //var count = selectionMgr.AddSelectionListObjects(ComWangling.ObjectArrayToDispatchWrapper(o.Objects), selectData);
-                    });
+                    .ForEach(o => doc.AddSelections(o.Mark, o.Objects));
             }
 
             return Disposable.Create(() => doc.ClearSelections(selections));

--- a/SolidworksAddinFramework/ModelDocExtensions.cs
+++ b/SolidworksAddinFramework/ModelDocExtensions.cs
@@ -16,6 +16,7 @@ using SolidWorks.Interop.sldworks;
 using SolidWorks.Interop.swconst;
 using static LanguageExt.Parsec.Prim;
 using static LanguageExt.Parsec.Char;
+using Environment = System.Environment;
 
 namespace SolidworksAddinFramework
 {
@@ -160,16 +161,47 @@ namespace SolidworksAddinFramework
             return Tuple(selectedObjects, marks, views);
         }
 
+        /// <summary>
+        /// Gets an object from its persist reference.
+        /// 
+        /// This method currently tries to call all available versions of `GetObjectByPersistReference`
+        /// because we saw the latest one failing where it shouldn't fail. The other two versions succeeded.
+        /// We sent a bug report to the SW API support.
+        /// </summary>
+        /// <param name="doc"></param>
+        /// <param name="persistId"></param>
+        /// <returns></returns>
         public static object GetObjectFromPersistReference(this IModelDoc2 doc, byte[] persistId)
         {
-            int errorCode;
-            var @object = doc.Extension.GetObjectByPersistReference3(persistId, out errorCode);
-            var result = (swPersistReferencedObjectStates_e) errorCode;
-            if (result != swPersistReferencedObjectStates_e.swPersistReferencedObject_Ok)
+            var errors = new List<string>();
             {
-                throw new SelectionException($"GetObjectByPersistReference3 returned {result}");
+                int errorCode;
+                var @object = doc.Extension.GetObjectByPersistReference3(persistId, out errorCode);
+                if (errorCode == (int)swPersistReferencedObjectStates_e.swPersistReferencedObject_Ok)
+                {
+                    return @object;
+                }
+                errors.Add($"`GetObjectByPersistReference3` returned `{(swPersistReferencedObjectStates_e)errorCode}`");
             }
-            return @object;
+            {
+                int errorCode;
+                var @object = doc.Extension.GetObjectByPersistReference2(persistId, out errorCode);
+                if (errorCode == (int)swPersistReferencedObjectStates_e.swPersistReferencedObject_Ok)
+                {
+                    return @object;
+                }
+                errors.Add($"`GetObjectByPersistReference2` returned `{(swPersistReferencedObjectStates_e)errorCode}`");
+            }
+            {
+                var @object = doc.Extension.GetObjectByPersistReference(persistId);
+                if (@object != null)
+                {
+                    return @object;
+                }
+                errors.Add("`GetObjectByPersistReference` returned `null`");
+            }
+            var nl = Environment.NewLine;
+            throw new SelectionException("Can't get object from persist id:" + nl + string.Join(nl, errors));
         }
 
         /// <summary>
@@ -179,7 +211,7 @@ namespace SolidworksAddinFramework
         /// <param name="modelDoc"></param>
         /// <param name="obj">Entity with a valid persist reference</param>
         /// <returns></returns>
-        public static Func<T> GetPersistentEntityReference<T>(IModelDoc2 modelDoc, T obj)
+        public static Func<T> GetPersistentEntityReference<T>(this IModelDoc2 modelDoc, T obj)
         {
             var persistReference = modelDoc.Extension.GetPersistReference(obj).CastArray<byte>();
             return fun(() => (T)GetObjectFromPersistReference(modelDoc, persistReference));

--- a/SolidworksAddinFramework/SelectionData.cs
+++ b/SolidworksAddinFramework/SelectionData.cs
@@ -115,17 +115,7 @@ namespace SolidworksAddinFramework
         public static IEnumerable<object> GetObjects(this SelectionData selectionData, IModelDoc2 doc)
         {
             return selectionData.ObjectIds
-                .Select(objectId =>
-                {
-                    int errorCode;
-                    var @object = doc.Extension.GetObjectByPersistReference3(objectId.Data, out errorCode);
-                    var result = (swPersistReferencedObjectStates_e) errorCode;
-                    if (result != swPersistReferencedObjectStates_e.swPersistReferencedObject_Ok)
-                    {
-                        throw new SelectionException($"GetObjectByPersistReference3 returned {result}");
-                    }
-                    return @object;
-                });
+                .Select(objectId => doc.GetObjectFromPersistReference(objectId.Data));
         }
 
         /// <summary>

--- a/XUnit.Solidworks.Addin/SpecHelper.cs
+++ b/XUnit.Solidworks.Addin/SpecHelper.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using SolidworksAddinFramework;
+using SolidWorks.Interop.sldworks;
+using SolidWorks.Interop.swconst;
+
+namespace XUnit.Solidworks.Addin
+{
+    public static class SpecHelper
+    {
+        public static Feature InsertDummyBody(IModelDoc2 modelDoc)
+        {
+            modelDoc.Extension.SelectByID2("Front Plane", "PLANE", 0, 0, 0, true, 0, null, 0).Should().BeTrue();
+            var plane1 = (RefPlane)modelDoc.FeatureManager.InsertRefPlane(8, 0.01, 0, 0, 0, 0);
+            modelDoc.Extension.SelectByID2("Front Plane", "PLANE", 0, 0, 0, true, 0, null, 0).Should().BeTrue();
+            var plane2 = (RefPlane)modelDoc.FeatureManager.InsertRefPlane(8, 0.02, 0, 0, 0, 0);
+
+            modelDoc.Extension.SelectByID2("Plane2", "PLANE", 0, 0, 0, false, 0, null, 0).Should().BeTrue();
+            var lines =
+                modelDoc.SketchManager.CreateCornerRectangle(-0.02, 0.01, 0, 0.02, -0.01, 0)
+                    .CastArray<ISketchSegment>();
+            // Sketch to extrude
+            modelDoc.Extension.SelectByID2("Sketch1", "SKETCH", 0, 0, 0, false, 0, null, 0).Should().BeTrue();
+            // Start condition reference
+            modelDoc.Extension.SelectByID2("Plane2", "PLANE", 0.00105020593408751, -0.00195369982668282,
+                0.0248175428318827, true, 32, null, 0).Should().BeTrue();
+            // End condition reference
+            modelDoc.Extension.SelectByID2("Plane1", "PLANE", 0.0068370744701368, -0.004419862088339,
+                0.018892268568016, true, 1, null, 0).Should().BeTrue();
+
+            // Boss extrusion start condition reference is Plane2, and the extrusion end is offset 3 mm from the end condition reference, Plane1
+            return modelDoc.FeatureManager.FeatureExtrusion3(true, false, true,
+                (int)swEndConditions_e.swEndCondOffsetFromSurface, 0, 0.003, 0.003, false, false, false,
+                false, 0.0174532925199433, 0.0174532925199433, false, false, false, false, true, true, true,
+                (int)swStartConditions_e.swStartSurface, 0, false);
+        }
+    }
+}

--- a/XUnit.Solidworks.Addin/XUnit.Solidworks.Addin.csproj
+++ b/XUnit.Solidworks.Addin/XUnit.Solidworks.Addin.csproj
@@ -280,6 +280,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="SolidWorksSpec.cs" />
+    <Compile Include="SpecHelper.cs" />
     <Compile Include="SwAddin.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
This should solve #18 by converting an entity to a `Func<entity>` that resolves the entity at every invocation according to its persistent reference.

However I am trying to come up with a test that shows that references can be invalidated, but I didn't succeed yet. Any ideas?
